### PR TITLE
The api doesn't support the session_id attribute in next method.

### DIFF
--- a/src/com/echonest/api/v4/DynamicPlaylistSession.java
+++ b/src/com/echonest/api/v4/DynamicPlaylistSession.java
@@ -96,7 +96,7 @@ public class DynamicPlaylistSession {
             lookaheadResults.add(song);
         }
 
-        Playlist playlist = new Playlist(songResults, lookaheadResults, session);
+        Playlist playlist = new Playlist(songResults, lookaheadResults, sessionID);
         return playlist;
     }
 


### PR DESCRIPTION
When next method is called in playlist/dynamic/next the attribute session_id is not returned anymore.
