### PR TITLE
Wrong call of webservice

### DIFF
--- a/src/com/echonest/api/v4/EchoNestAPI.java
+++ b/src/com/echonest/api/v4/EchoNestAPI.java
@@ -485,7 +485,6 @@ public class EchoNestAPI {
 
         p.add("url", trackUrl.toExternalForm());
         p.add("wait", wait ? "true" : "false");
-        p.add("upload", (String) null);
         if (wait) {
             p.add("bucket", "audio_summary");
         }


### PR DESCRIPTION
If you add the parameter upload = null when calling echonest webservice with the URL of a song it will retrieve an error like: wrong parameter upload. Tested it without this parameter and it worked fine. 
