### PR TITLE
Removed 'upload' parameter from upload request

### DIFF
--- a/src/com/echonest/api/v4/EchoNestAPI.java
+++ b/src/com/echonest/api/v4/EchoNestAPI.java
@@ -485,7 +485,6 @@ public class EchoNestAPI {
 
         p.add("url", trackUrl.toExternalForm());
         p.add("wait", wait ? "true" : "false");
-        p.add("upload", (String) null);
         if (wait) {
             p.add("bucket", "audio_summary");
         }


### PR DESCRIPTION
The 'upload' parameter is not allowed when uploading by URL, resulting in this error: 

`com.echonest.api.v4.EchoNestException: (5) method - Invalid parameter: "upload"`
